### PR TITLE
Add support for users with UIDs larger than 256000.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,12 @@ RUN apk add --no-cache --virtual .build-dependencies build-base curl && \
     cp src/unison src/unison-fsmonitor /usr/local/bin && \
     apk del .build-dependencies ocaml && \
     rm -rf /tmp/unison-${UNISON_VERSION}
+    # Create user
+    echo "docker:x:$HOST_UID:$HOST_UID::/home/docker:" >> /etc/passwd && \
+    ## thanks for http://stackoverflow.com/a/1094354/535203 to compute the creation date
+    echo "docker:!:$(($(date +%s) / 60 / 60 / 24)):0:99999:7:::" >> /etc/shadow && \
+    echo "docker:x:$HOST_UID:" >> /etc/group && \
+    mkdir /home/docker && chown docker: /home/docker
 
 ENV HOME="/root" \
     UNISON_USER="root" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,6 @@ RUN apk add --no-cache --virtual .build-dependencies build-base curl && \
     cp src/unison src/unison-fsmonitor /usr/local/bin && \
     apk del .build-dependencies ocaml && \
     rm -rf /tmp/unison-${UNISON_VERSION}
-    # Create user
-    echo "docker:x:$HOST_UID:$HOST_UID::/home/docker:" >> /etc/passwd && \
-    ## thanks for http://stackoverflow.com/a/1094354/535203 to compute the creation date
-    echo "docker:!:$(($(date +%s) / 60 / 60 / 24)):0:99999:7:::" >> /etc/shadow && \
-    echo "docker:x:$HOST_UID:" >> /etc/group && \
-    mkdir /home/docker && chown docker: /home/docker
 
 ENV HOME="/root" \
     UNISON_USER="root" \

--- a/sync.sh
+++ b/sync.sh
@@ -65,7 +65,15 @@ if [[ "$UNISON_USER" != "root" ]]; then
   # Create user, if it does not exist
   if ! grep -q "$UNISON_USER" /etc/passwd; then
       log_info "Creating user $UNISON_USER (UID=$UNISON_UID,GID=$UNISON_GID)"
-      adduser -u "$UNISON_UID" -D -S -G "$UNISON_GROUP" "$UNISON_USER" -s "$SHELL"
+
+      # Create user in a way that allows high user IDs.
+      # @see https://stackoverflow.com/a/42133612/1483861
+      echo "$UNISON_USER:x:$UNISON_UID:$UNISON_UID::/home/$UNISON_USER:" >> /etc/passwd
+      # Compute creation date
+      # @see http://stackoverflow.com/a/1094354/535203
+      echo "$UNISON_USER:!:$(($(date +%s) / 60 / 60 / 24)):0:99999:7:::" >> /etc/shadow
+      echo "$UNISON_GROUP:x:$UNISON_UID:" >> /etc/group
+      mkdir /home/${UNISON_USER} && chown ${UNISON_USER}: /home/${UNISON_USER}
   fi
 
   # Create unison directory


### PR DESCRIPTION
If you have a large user ID (say, your work laptop was setup so that your user ID locally matches your user ID in company systems), you'll run into an issue using Docksal's unison where it prints this out repeatedly until you forcibly stop the script:

`unison_1 | adduser: number 256001 is not in 0..256000 range`

Or sometimes it prints this instead:

`unison_1 | -----> Creating user docker (UID=256001,GID=256001)`

The issue is described here:

https://stackoverflow.com/a/42133612/1483861

And this PR applies the solution therein.

If you want to apply this locally, you can edit `~/.docksal/stacks/volumes-unison.yml` to replace `image: docksal/unison` with `build: ~/.docksal/stacks/unison` and then clone this fork into `~/.docksal/stacks`.

There are probably better ways to do this but this is my hack to get the ball rolling.