### PR TITLE
Replace Alpine linux with Debian Linux.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,19 @@
-FROM alpine:3.5
-
-# Alpine doesn't ship with Bash.
-RUN apk add --no-cache bash
+FROM debian:stretch-slim
 
 # Install Unison from source with inotify support + remove compilation tools
 ARG UNISON_VERSION=2.48.4
-RUN apk add --no-cache --virtual .build-dependencies build-base curl && \
-    apk add --no-cache inotify-tools && \
-    apk add --no-cache --repository http://dl-4.alpinelinux.org/alpine/edge/testing/ ocaml && \
-    curl -L https://github.com/bcpierce00/unison/archive/$UNISON_VERSION.tar.gz | tar zxv -C /tmp && \
+
+RUN apt-get update && apt-get install -y curl inotify-tools build-essential ocaml-nox ctags
+
+RUN curl -L https://github.com/bcpierce00/unison/archive/$UNISON_VERSION.tar.gz | tar zxv -C /tmp && \
     cd /tmp/unison-${UNISON_VERSION} && \
     sed -i -e 's/GLIBC_SUPPORT_INOTIFY 0/GLIBC_SUPPORT_INOTIFY 1/' src/fsmonitor/linux/inotify_stubs.c && \
     make UISTYLE=text NATIVE=true STATIC=true && \
     cp src/unison src/unison-fsmonitor /usr/local/bin && \
-    apk del .build-dependencies ocaml && \
     rm -rf /tmp/unison-${UNISON_VERSION}
+
+RUN apt-get remove -y build-essential ocaml-nox
+RUN apt-get install -y procps
 
 ENV HOME="/root" \
     UNISON_USER="root" \

--- a/sync.sh
+++ b/sync.sh
@@ -59,13 +59,14 @@ if [[ "$UNISON_USER" != "root" ]]; then
   # Create group, if it does not exist
   if ! grep -q "$UNISON_GROUP" /etc/group; then
       log_info "Creating group $UNISON_GROUP"
-      addgroup -g "$UNISON_GID" -S "$UNISON_GROUP"
+      addgroup --gid "$UNISON_GID" --system "$UNISON_GROUP"
   fi
 
   # Create user, if it does not exist
   if ! grep -q "$UNISON_USER" /etc/passwd; then
       log_info "Creating user $UNISON_USER (UID=$UNISON_UID,GID=$UNISON_GID)"
-      adduser -u "$UNISON_UID" -D -S -G "$UNISON_GROUP" "$UNISON_USER" -s "$SHELL"
+      GID=$(getent group "$UNISON_GROUP" | cut -d: -f3)
+      adduser --uid "$UNISON_UID" --disabled-password --system --gid "$GID" --shell "$SHELL" "$UNISON_USER"
   fi
 
   # Create unison directory


### PR DESCRIPTION
This PR fixes the error:  "unison_1 | adduser: 646227958 number is not in 0..256000 range" 
 646227958 is the user id that the container is configured to use for the docker user within my docksal images.  I checked another colleague's system, this same user id was 502.  I have no idea why they are different.  But I have seen at least one other report on the internet of a high user id like this.

This fix works by replacing Alpine linux with Debian linux.  Alpine linux does not support users greater than 256000 apparently.  Since Debian does support user ids in this range it solves the problem.

So far, I've only tested this on my machine.
