### PR TITLE
Use shadow based useradd and groupadd user management to fix > 256000…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache bash
 ARG UNISON_VERSION=2.48.4
 RUN apk add --no-cache --virtual .build-dependencies build-base curl && \
     apk add --no-cache inotify-tools && \
+    apk add --no-cache shadow && rm /etc/default/useradd && \
     apk add --no-cache --repository http://dl-4.alpinelinux.org/alpine/edge/testing/ ocaml && \
     curl -L https://github.com/bcpierce00/unison/archive/$UNISON_VERSION.tar.gz | tar zxv -C /tmp && \
     cd /tmp/unison-${UNISON_VERSION} && \
@@ -15,6 +16,8 @@ RUN apk add --no-cache --virtual .build-dependencies build-base curl && \
     cp src/unison src/unison-fsmonitor /usr/local/bin && \
     apk del .build-dependencies ocaml && \
     rm -rf /tmp/unison-${UNISON_VERSION}
+
+RUN apk add --no-cache su-exec
 
 ENV HOME="/root" \
     UNISON_USER="root" \
@@ -25,5 +28,6 @@ ENV HOME="/root" \
 # Copy the bg-sync script into the container.
 COPY sync.sh /usr/local/bin/bg-sync
 RUN chmod +x /usr/local/bin/bg-sync
+
 
 CMD ["bg-sync"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,5 @@ ENV HOME="/root" \
 COPY sync.sh /usr/local/bin/bg-sync
 RUN chmod +x /usr/local/bin/bg-sync
 
-
 CMD ["bg-sync"]
+

--- a/sync.sh
+++ b/sync.sh
@@ -59,13 +59,13 @@ if [[ "$UNISON_USER" != "root" ]]; then
   # Create group, if it does not exist
   if ! grep -q "$UNISON_GROUP" /etc/group; then
       log_info "Creating group $UNISON_GROUP"
-      addgroup -g "$UNISON_GID" -S "$UNISON_GROUP"
+      groupadd --gid "$UNISON_GID" --system "$UNISON_GROUP"
   fi
 
   # Create user, if it does not exist
   if ! grep -q "$UNISON_USER" /etc/passwd; then
       log_info "Creating user $UNISON_USER (UID=$UNISON_UID,GID=$UNISON_GID)"
-      adduser -u "$UNISON_UID" -D -S -G "$UNISON_GROUP" "$UNISON_USER" -s "$SHELL"
+      useradd --shell "$SHELL" --uid "$UNISON_UID" --system -g "$UNISON_GROUP" "$UNISON_USER"
   fi
 
   # Create unison directory
@@ -187,7 +187,7 @@ log_heading "Starting continuous sync."
 # su -c "unison default" -s /bin/sh "${UNISON_USER}"
 
 if [[ "$UNISON_USER" != "root" ]]; then
-  su "${UNISON_USER}" -c "unison default"
+  su-exec "${UNISON_USER}" unison default
 else
   unison default
 fi


### PR DESCRIPTION
… UID issue.

Also uses su-exec instead of su.  Apparently installing shadow causes su to require a password.  Upon research discovered that the intended use case for su is for an unprivileged user to become privileged, and that's why the password is required.  su-exec is intended for the use case of a privileged user becoming less privileged, and does not require a password.