### PR TITLE
Updates readme to fix incorrect config documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Unison container suited for Docksal needs. Continuously syncs files between two 
 1. Add to the `docksal.env`:
 
     ```
-    DOCKER_VOLUMES=unison
+    DOCKSAL_VOLUMES=unison
     ```
 
 1. If your project was running before, then remove old containers and volumes with `fin project remove`


### PR DESCRIPTION
Readme file contains an error in documentation for enabling Unison, this change resolves the discrepancy between readme and https://docs.docksal.io/core/volumes/.